### PR TITLE
Cir 399 add set default transformer

### DIFF
--- a/lib/rhykane/transformer.rb
+++ b/lib/rhykane/transformer.rb
@@ -25,6 +25,12 @@ class Rhykane
 
         Dry::Transformer::HashTransformations.nest(row, key, *vals)
       end
+
+      def set_default(row, default)
+        Hash[row].tap do |r|
+          default.each { |k, v| r[k] = v if r[k].nil? }
+        end
+      end
     end
 
     def initialize(row: [], values: {}, **)

--- a/lib/rhykane/transformer.rb
+++ b/lib/rhykane/transformer.rb
@@ -27,7 +27,7 @@ class Rhykane
       end
 
       def set_default(row, default)
-        Hash[row].tap { |r| default.each { |k, v| x[k] ||= v } }
+        Hash[row].tap { |r| default.each { |k, v| r[k] ||= v } }
       end
     end
 

--- a/lib/rhykane/transformer.rb
+++ b/lib/rhykane/transformer.rb
@@ -27,7 +27,7 @@ class Rhykane
       end
 
       def set_default(row, default)
-        Hash[row].tap { |r| default.each { |k, v| r[k] ||= v } }
+        row.to_h.tap { |r| default.each { |k, v| r[k] ||= v } }
       end
     end
 

--- a/lib/rhykane/transformer.rb
+++ b/lib/rhykane/transformer.rb
@@ -27,9 +27,7 @@ class Rhykane
       end
 
       def set_default(row, default)
-        Hash[row].tap do |r|
-          default.each { |k, v| r[k] = v if r[k].nil? || r[k].empty?}
-        end
+        Hash[row].tap { |r| default.each { |k, v| r[k] ||= v } }
       end
     end
 

--- a/lib/rhykane/transformer.rb
+++ b/lib/rhykane/transformer.rb
@@ -27,7 +27,7 @@ class Rhykane
       end
 
       def set_default(row, default)
-        Hash[row].tap { |r| default.each { |k, v| r[k] ||= v } }
+        Hash[row].tap { |r| default.each { |k, v| x[k] ||= v } }
       end
     end
 

--- a/lib/rhykane/transformer.rb
+++ b/lib/rhykane/transformer.rb
@@ -28,7 +28,7 @@ class Rhykane
 
       def set_default(row, default)
         Hash[row].tap do |r|
-          default.each { |k, v| r[k] = v if r[k].nil? }
+          default.each { |k, v| r[k] = v if r[k].nil? || r[k].empty?}
         end
       end
     end

--- a/spec/fixtures/data_nil.tsv
+++ b/spec/fixtures/data_nil.tsv
@@ -1,0 +1,4 @@
+id	desc	total
+asdf	Foo Bar	100
+lkjh	Bar Foo	20000
+qwer

--- a/spec/fixtures/rhykane.yml
+++ b/spec/fixtures/rhykane.yml
@@ -38,6 +38,9 @@ map_b:
         - :record_id
         - :title
         - :amount
+      set_default:
+        title: "default_value"
+        amount: "99"
   source:
     bucket: "foo"
     key: "data.tsv"

--- a/spec/rhykane/transform_spec.rb
+++ b/spec/rhykane/transform_spec.rb
@@ -21,5 +21,19 @@ describe Rhykane::Transform do
       expect(result[1..]).to eq expected
       expect(result.first).to eq cfg.dig(:destination, :opts, :headers).map(&:to_s)
     end
+
+    it 'sets default values when passed the set_default configuration' do
+      cfg_path   = './spec/fixtures/rhykane.yml'
+      cfg        = Rhykane::Jobs.load(cfg_path)[:map_b]
+      input_path = Pathname('./spec/fixtures/data_nil.tsv')
+      input      = input_path.open
+      output     = StringIO.new
+      expected   = [['asdf', 'Foo Bar', '100'], ['lkjh', 'Bar Foo', '20000'], ['qwer', 'default_value', '99']]
+
+      described_class.(input, output, **cfg)
+      result = CSV.parse(output.string)
+
+      expect(result[1..]).to eq expected
+    end
   end
 end

--- a/spec/rhykane/transformer_spec.rb
+++ b/spec/rhykane/transformer_spec.rb
@@ -64,7 +64,7 @@ describe Rhykane::Transformer do
       cfg      = { row: { set_default: { desc: 'default value', total: 999 } } }
       opts     = { col_sep: "\t", headers: true, header_converters: :symbol }
       data     = CSV.open(Pathname('./spec/fixtures/data_nil.tsv'), **opts)
-      expected = data.to_a.map { |r| r.to_h.tap { |h| h = h.merge!(cfg.dig(:row, :set_default)) if h[:desc].nil? } }
+      expected = data.to_a.map { |r| r.to_h.tap { |h| h.merge!(cfg.dig(:row, :set_default)) if h[:desc].nil? } }
       data.rewind
 
       result = described_class.(data, **cfg).each.to_a

--- a/spec/rhykane/transformer_spec.rb
+++ b/spec/rhykane/transformer_spec.rb
@@ -60,6 +60,18 @@ describe Rhykane::Transformer do
       expect(result).to eq expected
     end
 
+    it 'allows setting default value if original value is nil' do
+      cfg      = { row: { set_default: { desc: 'default value', total: 999 } } }
+      opts     = { col_sep: "\t", headers: true, header_converters: :symbol }
+      data     = CSV.open(Pathname('./spec/fixtures/data_nil.tsv'), **opts)
+      expected = data.to_a.map { |r| r.to_h.tap { |h| h = h.merge!(cfg.dig(:row, :set_default)) if h[:desc].nil? } }
+      data.rewind
+
+      result = described_class.(data, **cfg).each.to_a
+
+      expect(result).to eq expected
+    end
+
     it 'sets up transformation pipeline from config' do
       cfg_path   = './spec/fixtures/rhykane.yml'
       cfg        = Rhykane::Jobs.load(cfg_path)[:map_a]


### PR DESCRIPTION
### WHY
We were running into issues with the amazon file we were trying to map where certain fields were causing ingestion to fail due to null values so we decided to add a set_default transformer where they key is the field and the value is the default set if the original value is null.

### HOW
Adds set_default transformer and spec

### ALSO
