### PR TITLE
CIR-938-create-io-class

### DIFF
--- a/lib/rhykane/config.rb
+++ b/lib/rhykane/config.rb
@@ -19,7 +19,7 @@ class Rhykane
     }
 
     params do
-      required(:transforms).hash(TransformsSchema)
+      optional(:transforms).hash(TransformsSchema)
       required(:source).hash(DataSchema)
       required(:destination).hash(DataSchema)
     end

--- a/lib/rhykane/reader.rb
+++ b/lib/rhykane/reader.rb
@@ -28,7 +28,7 @@ class Rhykane
       end
     end
 
-    class IO > Reader
+    class IO < Reader
     end
 
     class JSON < Reader

--- a/lib/rhykane/reader.rb
+++ b/lib/rhykane/reader.rb
@@ -28,6 +28,9 @@ class Rhykane
       end
     end
 
+    class IO > Reader
+    end
+
     class JSON < Reader
       include Enumerable
 

--- a/lib/rhykane/writer.rb
+++ b/lib/rhykane/writer.rb
@@ -37,7 +37,7 @@ class Rhykane
       end
     end
 
-    class IO > Writer
+    class IO < Writer
     end
 
     class JSON < Writer

--- a/lib/rhykane/writer.rb
+++ b/lib/rhykane/writer.rb
@@ -37,6 +37,9 @@ class Rhykane
       end
     end
 
+    class IO > Writer
+    end
+
     class JSON < Writer
       def initialize(*, **)
         super


### PR DESCRIPTION
### WHY
Creates process to rename files without mapping

### HOW
IO inherits from Reader/Writer class and can be passed into opts in the Circe filemapper
Allows for transforms hash to be optional

### ALSO
