### PR TITLE
CIR-938-allow-renaming-only

### DIFF
--- a/lib/rhykane/reader.rb
+++ b/lib/rhykane/reader.rb
@@ -28,7 +28,10 @@ class Rhykane
       end
     end
 
-    class IO < Reader
+    class IO < SimpleDelegator
+      def initialize(io, opts: {}, **)
+        super(io)
+      end
     end
 
     class JSON < Reader

--- a/lib/rhykane/reader.rb
+++ b/lib/rhykane/reader.rb
@@ -29,7 +29,7 @@ class Rhykane
     end
 
     class IO < SimpleDelegator
-      def initialize(io, opts: {}, **)
+      def initialize(io, **)
         super(io)
       end
     end

--- a/lib/rhykane/writer.rb
+++ b/lib/rhykane/writer.rb
@@ -38,6 +38,9 @@ class Rhykane
     end
 
     class IO < Writer
+      def puts(*rows)
+        io.puts(*rows)
+      end
     end
 
     class JSON < Writer

--- a/spec/fixtures/io_opts.yml
+++ b/spec/fixtures/io_opts.yml
@@ -1,0 +1,11 @@
+map_a:
+  transforms:
+    empty: "empty"
+  source:
+    bucket: "foo"
+    key: "data.tsv"
+    type: "io"
+  destination:
+    bucket: "bar"
+    key: "data.csv"
+    type: "io"

--- a/spec/rhykane_spec.rb
+++ b/spec/rhykane_spec.rb
@@ -70,6 +70,21 @@ describe Rhykane do
     ensure
       dest_path.delete if dest_path.exist?
     end
+
+    it 'reads a file from S3, renames it, and writes it back to a file in S3' do
+      cfg        = Rhykane::Jobs.load('./spec/fixtures/io_opts.yml')[:map_a]
+      input_path = Pathname('./spec/fixtures/data.tsv')
+      input      = input_path.open
+      res        = stub_s3_resource(stub_responses: { get_object: { body: input } })
+      dest_path  = s3_path(*cfg[:destination].values_at(:bucket, :key)).tap { |p| p.delete if p.exist? }
+
+      described_class.(res, **cfg)
+
+      expect(dest_path.read).to eq(input_path.read + "\n")
+
+    ensure
+      dest_path.delete if dest_path.exist?
+    end
   end
 
   describe '.for' do


### PR DESCRIPTION
### WHY
Allows the renaming of files without mapping the data

### HOW


### ALSO
