### PR TITLE
CIR-1135-add-mapping-functions-allow-null

### DIFF
--- a/lib/rhykane/functions.rb
+++ b/lib/rhykane/functions.rb
@@ -52,13 +52,13 @@ module Functions
 
   def upcase(original)
     return unless original
-    
+
     original.upcase
   end
 
   def split(original)
     return unless original
-
+    
     original.split.first
   end
 end

--- a/lib/rhykane/functions.rb
+++ b/lib/rhykane/functions.rb
@@ -58,7 +58,7 @@ module Functions
 
   def split(original)
     return unless original
-    
+
     original.split.first
   end
 end

--- a/lib/rhykane/functions.rb
+++ b/lib/rhykane/functions.rb
@@ -51,10 +51,14 @@ module Functions
   end
 
   def upcase(original)
+    return unless original
+    
     original.upcase
   end
 
   def split(original)
+    return unless original
+
     original.split.first
   end
 end


### PR DESCRIPTION
### WHY
Fields using these functions are not mandatory and not always filled

### HOW


### ALSO
