### PR TITLE
CIR-1193-thread-error-handling

### DIFF
--- a/lib/rhykane/s3/put.rb
+++ b/lib/rhykane/s3/put.rb
@@ -13,11 +13,7 @@ class Rhykane
         end
       end
 
-      def call(input_io)
-        object.upload_stream do |stream|
-          IO.copy_stream(input_io, stream)
-        end
-      end
+      def call(input_io) = object.upload_stream do |stream| IO.copy_stream(input_io, stream) end
     end
   end
 end

--- a/spec/rhykane/s3/get_spec.rb
+++ b/spec/rhykane/s3/get_spec.rb
@@ -7,17 +7,56 @@ describe Rhykane::S3::Get do
     it 'streams file in s3 to a pipe and yields the pipe' do
       bucket, key = 'foo', 'streamable.txt'
       result      = StringIO.new
-      io          = StringIO.new.tap { |s|
-        s.puts(*Array.new(1024) { 'a' * 1024 })
-        s.rewind
-      }
-      res = stub_s3_resource(stub_responses: { get_object: { body: io } })
+      io          = StringIO.new(Array.new(1024) { 'a' * 1024 }.join("\n"))
+      cli         = stub_s3_resource(stub_responses: { get_object: { body: io } })
 
-      described_class.(res, bucket:, key:) do |rd|
-        IO.copy_stream(rd, result)
-      end
+      described_class.(cli, bucket:, key:) do |rd| IO.copy_stream(rd, result) end
 
       expect(result.string).to eq io.string
+    end
+
+    it 'handles exceptions raised by the caller, gracefully shutting down' do
+      bucket, key                = 'foo', 'streamable.txt'
+      err                        = Class.new(StandardError)
+      result                     = StringIO.new
+      io                         = StringIO.new(Array.new(1024) { 'a' * 1024 }.join("\n"))
+      cli                        = stub_s3_resource(stub_responses: { get_object: { body: io } })
+      orig_roe                   = Thread.report_on_exception
+      Thread.report_on_exception = false
+
+      expect {
+        described_class.(cli, bucket:, key:) do |rd|
+          result << rd.readline
+          raise err, result.string
+        end
+      }.to raise_error err, io.tap(&:rewind).string.lines.first
+    ensure
+      Thread.report_on_exception = orig_roe || false
+    end
+
+    it 'handles exceptions raised by reading, gracefully shutting down' do
+      bucket, key = 'foo', 'streamable.txt'
+      result      = StringIO.new
+      data        = Array.new(1024) { 'a' * 1024 }.join("\n")
+      chunks      = data.chars.each_slice(data.size.divmod(3).first).map(&:join)
+      err         = Class.new(StandardError)
+      err_msg     = 'Ack!'
+      cli         = stub_s3_resource(stub_responses: {
+                                       get_object: ->(ctx) {
+                                         chunks.each_with_index { |chunk, idx|
+                                           raise err, err_msg unless idx < 1
+
+                                           ctx[:response_target].(chunk)
+                                           sleep 0.1
+                                         }
+                                       }
+                                     })
+
+      expect {
+        described_class.(cli, bucket:, key:) do |rd| IO.copy_stream(rd, result) end
+      }.to raise_error err, err_msg
+
+      expect(result.string).to eq(chunks.first)
     end
 
     it 'streams zip file in s3 to a pipe and yields the pipe' do

--- a/spec/rhykane_spec.rb
+++ b/spec/rhykane_spec.rb
@@ -20,6 +20,54 @@ describe Rhykane do
       dest_path.delete if dest_path.exist?
     end
 
+    it 'handles exceptions raised by the caller, gracefully shutting down' do
+      cfg       = Rhykane::Jobs.load(config_path)[:map_a]
+      input     = tsv_data.open
+      cli       = stub_s3_resource(stub_responses: { get_object: { body: input } })
+      err       = Class.new(StandardError)
+      dest_path = s3_path(*cfg[:destination].values_at(:bucket, :key)).tap { |p| p.delete if p.exist? }
+      expected  = CSV.read(tsv_data, **cfg.dig(:source, :opts)).first
+      result    = nil
+      orig_roe  = Thread.report_on_exception
+      Thread.report_on_exception = false
+
+      expect {
+        described_class.(cli, **cfg) do |row|
+          result = row
+          raise err, result.to_s
+        end
+      }.to raise_error err, expected.to_s
+
+      expect(dest_path).not_to be_exist
+    ensure
+      Thread.report_on_exception = orig_roe || false
+      dest_path.delete if dest_path.exist?
+    end
+
+    it 'handles exceptions raised by reading, gracefully shutting down' do
+      cfg       = Rhykane::Jobs.load(config_path)[:map_a]
+      chunks    = tsv_data.read.chars.each_slice(tsv_data.size.divmod(3).first).map(&:join)
+      err       = Class.new(StandardError)
+      err_msg   = 'Ack!'
+      dest_path = s3_path(*cfg[:destination].values_at(:bucket, :key)).tap { |p| p.delete if p.exist? }
+      cli       = stub_s3_resource(stub_responses: {
+                                     get_object: ->(ctx) {
+                                       chunks.each_with_index { |chunk, idx|
+                                         raise err, err_msg unless idx < 1
+
+                                         ctx[:response_target].(chunk)
+                                         sleep 0.1
+                                       }
+                                     }
+                                   })
+
+      expect { described_class.(cli, **cfg) }.to raise_error err, err_msg
+
+      expect(dest_path).not_to be_exist
+    ensure
+      dest_path.delete if dest_path.exist?
+    end
+
     it 'reads and parses tsv files in a zipped archive from S3, transforms them, ' \
        'and writes a single file back to S3' do
       cfg       = Rhykane::Jobs.load(config_path)[:zipped]


### PR DESCRIPTION
### WHY
Exceptions raised in threads were not being bubbled up to the caller because `Thread.current.abort_on_exception` was not set to true. When this is the case and threads are communicating via `IO.pipe`, the calling thread may hang indefinitely if the other thread has died without closing its end of the pipe.

### HOW
- Set `Thread.current.abort_on_exception = true` for child threads.
- Move writing to pipe to main thread, and reading from pipe to child thread.
- Handle exceptions, cleaning up pipes and threads appropriately.

### ALSO
