### PR TITLE
PER-160-unzip-amazon

### DIFF
--- a/lib/rhykane/s3/get.rb
+++ b/lib/rhykane/s3/get.rb
@@ -78,7 +78,7 @@ class Rhykane
             ::Zip::File.open_buffer(zip) do |zip_file| stream_entries(zip_file, wr_io) end
           end
         end
-        
+
         def new_zip_stream(zip, &) = ::Zip::InputStream.open(zip, 0, decrypter, &)
         def decrypter              = (pwd = opts[:password]) && Zip::TraditionalDecrypter.new(pwd)
 


### PR DESCRIPTION
### WHY
Getting this error now for Amazon:
`/usr/local/bundle/gems/rubyzip-2.3.2/lib/zip/input_stream.rb:132:in `open_entry': General purpose flag Bit 3 is set so not possible to get proper info from local header.Please use ::Zip::File instead of ::Zip::InputStream (Zip::GPFBit3Error)`

### HOW
Revert to ::Zip::File unless password

### ALSO
