### PR TITLE
CIR-1623-adjust-share-pct

### DIFF
--- a/lib/rhykane/transformer/transforms.rb
+++ b/lib/rhykane/transformer/transforms.rb
@@ -73,6 +73,10 @@ class Rhykane
 
         "PT#{h}H#{m}M#{s}S"
       end
+
+      def self.adjust_share(value)
+        value * 100
+      end
     end
   end
 end

--- a/spec/rhykane/transformer/transforms_spec.rb
+++ b/spec/rhykane/transformer/transforms_spec.rb
@@ -105,4 +105,11 @@ describe Rhykane::Transformer::Transforms do
 
     expect(result).to eq(5.0)
   end
+
+    it 'adusts share pct for splits reported incorrectly' do
+    submitted_share = 0.5
+    result = described_class.adjust_share(submitted_share)
+
+    expect(result).to eq(50.0)
+  end
 end


### PR DESCRIPTION
### WHY
Lyricfind, and possibly other legacy passthrough senders, report splits formatted as 0.5 instead of 50.0. Adds method to update share without needing preprocessing

### HOW


### ALSO
