### PR TITLE
CIR-1972 dynamically set part_size based on object size

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,11 +21,11 @@ jobs:
     env:
       GIT_BRANCH: ${{ github.ref_name }}
     steps:
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: build
         run: docker compose build
       - name: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - '**'
+permissions:
+  id-token: write
+  contents: read
 
 defaults:
   run:
@@ -17,23 +20,19 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GIT_BRANCH: ${{ github.ref_name }}
-      CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
     steps:
       - uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v3
-      - name: coverage before-build
-        run: |
-          set -x
-          curl -sL https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cctr
-          chmod +x ./cctr
-          ./cctr before-build
       - name: build
         run: docker compose build
       - name: test
         run: docker compose run --rm rhykane bundle exec rspec
       - name: coverage
-        run: |
-          ./cctr after-build -p /var/app -t simplecov
+        uses: qltysh/qlty-action/coverage@v1
+        with:
+          oidc: true
+          strip-prefix: /var/app
+          files: coverage/coverage.json

--- a/lib/rhykane/s3/put.rb
+++ b/lib/rhykane/s3/put.rb
@@ -13,7 +13,17 @@ class Rhykane
         end
       end
 
-      def call(input_io) = object.upload_stream do |stream| IO.copy_stream(input_io, stream) end
+      def call(input_io) = object.upload_stream(part_size:) do |stream| IO.copy_stream(input_io, stream) end
+
+      private
+
+      def part_size
+        max_s3_parts      = 10_000
+        default_part_size = 5 * 1024 * 1024 # 5 MiB
+        calculated_size   = (object.content_length.fdiv(max_s3_parts)).ceil
+
+        [default_part_size, calculated_size].max
+      end
     end
   end
 end

--- a/spec/rhykane_spec.rb
+++ b/spec/rhykane_spec.rb
@@ -161,6 +161,29 @@ describe Rhykane do
     ensure
       dest_path.delete if dest_path.exist?
     end
+
+    it 'dynamically sets part_size of multipart upload based on object size' do
+      cfg        = Rhykane::Jobs.load(config_path)[:io]
+      input      = tsv_data.open
+
+      default_part_size = 5 * 1024 * 1024 # 5 MiB
+      object_size  = rand((10 * 1024 * 1024)..(100 * 1024 * 1024 * 1024)) # 10 MiB..100 GiB
+      max_s3_parts = 10_000 # S3 allows a maximum of 10,000 parts in a multipart upload
+      calculated_size = (object_size.fdiv(max_s3_parts)).ceil
+
+      res = stub_s3_resource(stub_responses: { get_object: { body: input }, head_object: { content_length: object_size } })
+      dest_path = s3_path(*cfg[:destination].values_at(:bucket, :key)).tap { |p| p.delete if p.exist? }
+
+      expect_any_instance_of(Aws::S3::Object).to receive(:upload_stream)
+        .with(hash_including(part_size: [default_part_size, calculated_size].max))
+        .and_call_original
+
+      described_class.(res, **cfg)
+
+      expect(dest_path.read).to eq(tsv_data.read)
+    ensure
+      dest_path.delete if dest_path.exist?
+    end
   end
 
   describe '.for' do


### PR DESCRIPTION
### WHY
Filemapper failed while processing a 100GB file with this error:
```
aws-sdk-s3/multipart_stream_uploader.rb:106:in `abort_upload': multipart upload failed: Part number must be an integer between 1 and 10000, inclusive
```

When calling `object.upload_stream` in [put.rb](https://github.com/sesac/rhykane/blob/main/lib/rhykane/s3/put.rb#L16), AWS SDK's [MultipartStreamUploader](https://github.com/aws/aws-sdk-ruby/blob/c7fd0205df7f430a758ccae16adf1788a68bc0ba/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_stream_uploader.rb#L54-L81) is called. A maximum of 10_000 parts can be uploaded, and the default `part_size` of each part is 5MiB, or `5 * 1024 * 1024`. This is enough to handle a 50GB file, but TikTok is sending us files upwards of 100GB.

Need to dynamically set the `part_size` of the upload_stream based on the file size.

### HOW
- If the default part_size is enough, use it. If not, find the minimum part_size needed to upload the entire object, based on its size.
