### PR TITLE
CIR-1972 get source object's size

### DIFF
--- a/lib/rhykane.rb
+++ b/lib/rhykane.rb
@@ -55,6 +55,6 @@ class Rhykane
   def new_reader(input)      = Reader.(input, **source)
   def new_writer(io)         = Writer.(io, **destination)
   def source                 = config[:source]
-  def destination            = config[:destination]
+  def destination            = config[:destination].merge(source_key: source[:key], source_bucket: source[:bucket])
   def transforms             = config[:transforms]
 end

--- a/lib/rhykane/s3/put.rb
+++ b/lib/rhykane/s3/put.rb
@@ -13,14 +13,22 @@ class Rhykane
         end
       end
 
-      def call(input_io) = object.upload_stream(part_size:) do |stream| IO.copy_stream(input_io, stream) end
+      def initialize(client = Aws::S3::Resource.new, bucket:, key:, source_bucket:, source_key:, **opts)
+        @opts = opts
+        @source_object      = client.bucket(source_bucket).object(source_key)
+        @destination_object = client.bucket(bucket).object(key)
+      end
+
+      def call(input_io) = destination_object.upload_stream(part_size:) do |stream| IO.copy_stream(input_io, stream) end
 
       private
+
+      attr_reader :opts, :source_object, :destination_object
 
       def part_size
         max_s3_parts      = 10_000
         default_part_size = 5 * 1024 * 1024 # 5 MiB
-        calculated_size   = (object.content_length.fdiv(max_s3_parts)).ceil
+        calculated_size   = (source_object.content_length.fdiv(max_s3_parts)).ceil
 
         [default_part_size, calculated_size].max
       end

--- a/spec/rhykane/s3/put_spec.rb
+++ b/spec/rhykane/s3/put_spec.rb
@@ -12,7 +12,7 @@ describe Rhykane::S3::Put do
         s.rewind
       }
 
-      described_class.(res, io, bucket:, key:)
+      described_class.(res, io, bucket:, key:, source_bucket: 'bar', source_key: 'bar.txt')
 
       expect(key_path.read).to eq io.tap(&:rewind).read
     end


### PR DESCRIPTION
### WHY
In [this PR](https://github.com/sesac/rhykane/pull/36), we set the `part_size` of the multipart upload in the `Rhykane::S3::Put` class based on the value of `object.content_length`. However, in the `Rhykane::S3::Put` class, `object` refers to the destination object, not the source object. This led to `Aws::S3::Errors::NotFound` being raised.

### HOW
Pass `source_bucket` and `source_key` into the `Rhykane::S3::Put` class, get the object in s3 with those params, and get its content_length. 
