### PR TITLE
CIR-1972 set part_size to 30MiB for all files

### DIFF
--- a/lib/rhykane.rb
+++ b/lib/rhykane.rb
@@ -55,6 +55,6 @@ class Rhykane
   def new_reader(input)      = Reader.(input, **source)
   def new_writer(io)         = Writer.(io, **destination)
   def source                 = config[:source]
-  def destination            = config[:destination].merge(source_key: source[:key], source_bucket: source[:bucket])
+  def destination            = config[:destination]
   def transforms             = config[:transforms]
 end

--- a/lib/rhykane/s3/put.rb
+++ b/lib/rhykane/s3/put.rb
@@ -5,6 +5,8 @@ require_relative 'get'
 class Rhykane
   module S3
     class Put < Get
+      PART_SIZE = 30 * 1024 * 1024 # 30 MiB
+
       class << self
         def call(*deps, **args)
           *rest, io = *deps
@@ -13,25 +15,7 @@ class Rhykane
         end
       end
 
-      def initialize(client = Aws::S3::Resource.new, bucket:, key:, source_bucket:, source_key:, **opts)
-        @opts = opts
-        @source_object      = client.bucket(source_bucket).object(source_key)
-        @destination_object = client.bucket(bucket).object(key)
-      end
-
-      def call(input_io) = destination_object.upload_stream(part_size:) do |stream| IO.copy_stream(input_io, stream) end
-
-      private
-
-      attr_reader :opts, :source_object, :destination_object
-
-      def part_size
-        max_s3_parts      = 10_000
-        default_part_size = 5 * 1024 * 1024 # 5 MiB
-        calculated_size   = (source_object.content_length.fdiv(max_s3_parts)).ceil
-
-        [default_part_size, calculated_size].max
-      end
+      def call(input_io) = object.upload_stream(part_size: PART_SIZE) do |stream| IO.copy_stream(input_io, stream) end
     end
   end
 end

--- a/spec/rhykane/s3/put_spec.rb
+++ b/spec/rhykane/s3/put_spec.rb
@@ -12,7 +12,7 @@ describe Rhykane::S3::Put do
         s.rewind
       }
 
-      described_class.(res, io, bucket:, key:, source_bucket: 'bar', source_key: 'bar.txt')
+      described_class.(res, io, bucket:, key:)
 
       expect(key_path.read).to eq io.tap(&:rewind).read
     end

--- a/spec/rhykane_spec.rb
+++ b/spec/rhykane_spec.rb
@@ -161,29 +161,6 @@ describe Rhykane do
     ensure
       dest_path.delete if dest_path.exist?
     end
-
-    it 'dynamically sets part_size of multipart upload based on object size' do
-      cfg        = Rhykane::Jobs.load(config_path)[:io]
-      input      = tsv_data.open
-
-      default_part_size = 5 * 1024 * 1024 # 5 MiB
-      object_size  = rand((10 * 1024 * 1024)..(100 * 1024 * 1024 * 1024)) # 10 MiB..100 GiB
-      max_s3_parts = 10_000 # S3 allows a maximum of 10,000 parts in a multipart upload
-      calculated_size = (object_size.fdiv(max_s3_parts)).ceil
-
-      res = stub_s3_resource(stub_responses: { get_object: { body: input }, head_object: { content_length: object_size } })
-      dest_path = s3_path(*cfg[:destination].values_at(:bucket, :key)).tap { |p| p.delete if p.exist? }
-
-      expect_any_instance_of(Aws::S3::Object).to receive(:upload_stream)
-        .with(hash_including(part_size: [default_part_size, calculated_size].max))
-        .and_call_original
-
-      described_class.(res, **cfg)
-
-      expect(dest_path.read).to eq(tsv_data.read)
-    ensure
-      dest_path.delete if dest_path.exist?
-    end
   end
 
   describe '.for' do


### PR DESCRIPTION
### WHY
In [this PR](https://github.com/sesac/rhykane/pull/36/changes), I dynamically set the `part_size` of the multipart upload in `Rhykane::S3::Put` based on the size of the source object. However, since the transformation of the file can make the resulting upload much larger, this approach fails.

For the sake of getting our very large TikTok files through testing, for now I'm assigning a default `part_size` value of 30 MiB, which is enough to upload a 300 GB file.
